### PR TITLE
Using flatMap interferes with parallelization

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function toFirehose(firehose, streamName, opts) {
             return {Data: x};
         }),
         _.batchWithTimeOrCount(batchTime, batchNumber),
-        _.flatMap(function (batch) {
+        _.map(function (batch) {
             var params = {
                 DeliveryStreamName: streamName,
                 Records: batch,


### PR DESCRIPTION
See this issue in the highland repo: https://github.com/caolan/highland/issues/36

Using `.map(...)` allows us to apply `.parallel(...)` after it for concurrent requests.
